### PR TITLE
Add ReplyTo option in MailjetEmailMessage

### DIFF
--- a/src/MailjetEmailMessage.php
+++ b/src/MailjetEmailMessage.php
@@ -161,7 +161,7 @@ class MailjetEmailMessage
             'Subject' => $this->subject,
         ];
 
-        if (filled($this->replyto)) {
+        if (filled($this->replyTo)) {
             $messagesData['ReplyTo'] = $this->replyTo;
         }
 

--- a/src/MailjetEmailMessage.php
+++ b/src/MailjetEmailMessage.php
@@ -22,7 +22,7 @@ class MailjetEmailMessage
 
     public ?array $from = null;
 
-    public ?array $replyto = null;
+    public ?array $replyTo = null;
     
     public bool $templateLanguage = true;
 
@@ -100,12 +100,12 @@ class MailjetEmailMessage
         return $this;
     }
 
-    public function replyto($name, $email = null): static
+    public function replyTo($name, $email = null): static
     {
         if (is_array($name)) {
-            $this->replyto = $name;
+            $this->replyTo = $name;
         } else {
-            $this->replyto = [
+            $this->replyTo = [
                 'Name' => $name,
                 'Email' => $email,
             ];
@@ -162,7 +162,7 @@ class MailjetEmailMessage
         ];
 
         if (filled($this->replyto)) {
-            $messagesData['ReplyTo'] = $this->replyto;
+            $messagesData['ReplyTo'] = $this->replyTo;
         }
 
         if (filled($this->variables)) {

--- a/src/MailjetEmailMessage.php
+++ b/src/MailjetEmailMessage.php
@@ -22,6 +22,8 @@ class MailjetEmailMessage
 
     public ?array $from = null;
 
+    public ?array $replyto = null;
+    
     public bool $templateLanguage = true;
 
     public array $variables = [];
@@ -98,6 +100,20 @@ class MailjetEmailMessage
         return $this;
     }
 
+    public function replyto($name, $email = null): static
+    {
+        if (is_array($name)) {
+            $this->replyto = $name;
+        } else {
+            $this->replyto = [
+                'Name' => $name,
+                'Email' => $email,
+            ];
+        }
+
+        return $this;
+    }
+
     public function templateLanguage(bool $templateLanguage): static
     {
         $this->templateLanguage = $templateLanguage;
@@ -144,6 +160,10 @@ class MailjetEmailMessage
             'TemplateLanguage' => $this->templateLanguage,
             'Subject' => $this->subject,
         ];
+
+        if (filled($this->replyto)) {
+            $messagesData['ReplyTo'] = $this->replyto;
+        }
 
         if (filled($this->variables)) {
             $messagesData['Variables'] = $this->variables;


### PR DESCRIPTION
Mailjet API allows to customise ReplyTo field in a message. Could be sometimes useful specially for contact form notifications.