### PR TITLE
Add sandbox mode (and Laravel 11 support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ MAIL_FROM_ADDRESS=
 MAIL_FROM_NAME=
 MAILJET_SMS_SENDER=
 MAILJET_DRY=true|false
+MAILJET_SANDBOX=true|false
 ```
 
 Make sure that MAIL_FROM_ADDRESS is an authenticated email on Mailjet, otherwise your emails will not be sent by the Mailjet API.
@@ -33,6 +34,8 @@ Make sure that MAIL_FROM_ADDRESS is an authenticated email on Mailjet, otherwise
 MAILJET_SMS_SENDER should be between 3 and 11 characters in length, only alphanumeric characters are allowed.
 
 When the dry mode is enabled, Mailjet API isn't called.
+
+When the sandbox mode is enabled, Mailjet API is called but the mail is not send by Mailjet (requires Send API v3.1).
 
 You can publish the configuration file with:
 

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^9|^10",
-        "illuminate/database": "^9|^10",
+        "illuminate/support": "^9|^10|^11",
+        "illuminate/database": "^9|^10|^11",
         "mailjet/mailjet-apiv3-php": "^1.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^9|^10|^11",
-        "illuminate/database": "^9|^10|^11",
+        "illuminate/support": "^9|^10|^11|^12",
+        "illuminate/database": "^9|^10|^11|^12",
         "mailjet/mailjet-apiv3-php": "^1.5"
     },
     "require-dev": {

--- a/config/mailjet.php
+++ b/config/mailjet.php
@@ -10,6 +10,7 @@ return [
     ],
     'smsFrom' => env('MAILJET_SMS_SENDER'),
     'dry' => (bool) env('MAILJET_DRY', false),
+    'sandbox' => (bool) env('MAILJET_SANDBOX', false),
     'options' => [
         'version' => 'v3.1',
     ],

--- a/src/MailjetEmailMessage.php
+++ b/src/MailjetEmailMessage.php
@@ -30,6 +30,13 @@ class MailjetEmailMessage
 
     public array $attachments = [];
 
+    public bool $sandboxMode = false;
+
+    public function __construct()
+    {
+        $this->sandboxMode = (bool) config('mailjet.sandbox', false);
+    }
+
     public function templateId(int $templateId): static
     {
         $this->templateId = $templateId;
@@ -177,6 +184,7 @@ class MailjetEmailMessage
             'Messages' => [
                 $messagesData,
             ],
+            'SandboxMode' => $this->sandboxMode,
         ];
     }
 }

--- a/tests/MailjetEmailMessageTest.php
+++ b/tests/MailjetEmailMessageTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use YieldStudio\LaravelMailjetNotifier\MailjetEmailMessage;
+
+test('SandboxMode is default false', function (): void {
+    $message = (new MailjetEmailMessage())->templateId(123);
+
+    expect($message->toArray()['SandboxMode'])->toBe(false);
+});
+
+test('SandboxMode is true when config is set', function (): void {
+    // Set sandbox value in config to true
+    config(['mailjet.sandbox' => true]);
+
+    $message = (new MailjetEmailMessage())->templateId(123);
+
+    expect($message->toArray()['SandboxMode'])->toBe(true);
+});


### PR DESCRIPTION
This PR adds the SandboxMode from Send API v3.1. 

The change is quite small, as it is only a value that is added to the message.

To make sure that is works, there is created tests for the MailjetEmailMessage

The package is also upgraded to support Laravel 11